### PR TITLE
fix: updated log4j

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -44,6 +44,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.15.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.15.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
### Related Issues

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228

### Description and Example

Updated log4j to fix its critical vulnerability.
