### PR TITLE
fix: updated log4j

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -18,6 +18,7 @@
 		<java.version>11</java.version>
 		<kotlin.version>1.4.21</kotlin.version>
 		<beagle.version>1.5.0</beagle.version>
+		<log4j2.version>2.16.0</log4j2.version>
 	</properties>
 
 	<dependencies>
@@ -43,16 +44,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.15.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.15.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
### Related Issues

https://cve.mitre.org/cgi-bin/cvename.cgi?nme=CVE-2021-45046

### Description and Example

Updated log4j to fix its critical vulnerability.