### PR TITLE
fix: updated log4j

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -18,7 +18,7 @@
 		<java.version>11</java.version>
 		<kotlin.version>1.4.21</kotlin.version>
 		<beagle.version>1.5.0</beagle.version>
-		<log4j2.version>2.16.0</log4j2.version>
+		<log4j2.version>2.17.0</log4j2.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
### Related Issues

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105

### Description and Example

Updated log4j to fix its critical vulnerability.